### PR TITLE
add optfunc2

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [cliff](https://github.com/openstack/cliff) - A framework for creating command-line programs with multi-level commands.
     * [python-fire](https://github.com/google/python-fire) - A library for creating command line interfaces from absolutely any Python object.
     * [python-prompt-toolkit](https://github.com/prompt-toolkit/python-prompt-toolkit) - A library for building powerful interactive command lines.
+    * [optfunc2](https://github.com/yjloong/optfunc2) - A package for python cli with very easy way.
 * Terminal Rendering
     * [alive-progress](https://github.com/rsalmei/alive-progress) - A new kind of Progress Bar, with real-time throughput, eta and very cool animations.
     * [asciimatics](https://github.com/peterbrittain/asciimatics) - A package to create full-screen text UIs (from interactive forms to ASCII animations).


### PR DESCRIPTION
## What is this Python project?

A package used to support function called in command line, auto tips and auto abbrev only with one annotation.

## What's the difference between this Python project and similar ones?

This only will be one annotation. 
Support all python types, such as list, dict, int, float,str.
There will be a strictly check about the type if it declared in function arguments.
This package use a pretty table to show tips. Very beautiful.
for existing project, only adding one line is OK to export the function to command line and generate tips automatically.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
